### PR TITLE
Audit fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .gitignore
 .idea
+CODE_REVIEW.md
+CHANGES.md

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Oxyplug - Technical SEO Audit
+# Oxyplug - Image Audit
 
 This extension is used for SEO purposes. (Only images for now)
 
@@ -26,10 +26,10 @@ The extension will display the issues the images might have:
 - The LCP image doesn't have decoding="sync"
 ## A Glance
 
-![Oxyplug - Technical SEO Audit Demo](https://www.oxyplug.com/wp-content/uploads/2024/04/oxyplug-technical-seo-audit.png)
+![Oxyplug - Image Audit Demo](https://www.oxyplug.com/wp-content/uploads/2024/04/oxyplug-technical-seo-audit.png)
 ## Installation
 
-- 1. Download the extension form here [Technical SEO Audit](https://www.oxyplug.com/wp-content/uploads/Technical-SEO-Audit.crx)
+- 1. Download the extension form here [Image Audit](https://www.oxyplug.com/wp-content/uploads/Technical-SEO-Audit.crx)
 - 2. Open your Chrome browser.
 - 3. Go to extensions page or enter `chrome://extensions` in your address bar and hit enter.
 - 4. Drag and drop the downloaded extension to the extension page.

--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "Oxyplug - Technical SEO Audit",
+    "message": "Oxyplug - Image Audit",
     "description": "The name of the extension."
   },
   "extensionDescription": {

--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extensionDescription": {
-    "message": "Audit your page images for SEO & performance: alt text, dimensions, file size, next-gen formats, lazy loading and LCP.",
+    "message": "دقّق صور صفحتك: النص البديل، الأبعاد، حجم الملف، الصيغ الحديثة، التحميل الكسول وLCP.",
     "description": "The description of the extension shown in the Chrome Web Store."
   }
 }

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "Oxyplug - Technical SEO Audit",
+    "message": "Oxyplug - Image Audit",
     "description": "The name of the extension."
   },
   "extensionDescription": {

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extensionDescription": {
-    "message": "Audit your page images for SEO & performance: alt text, dimensions, file size, next-gen formats, lazy loading and LCP.",
+    "message": "Prüfe die Bilder deiner Seite: Alt-Text, Größe, Dateigröße, moderne Formate, Lazy-Loading und LCP.",
     "description": "The description of the extension shown in the Chrome Web Store."
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "Oxyplug - Technical SEO Audit",
+    "message": "Oxyplug - Image Audit",
     "description": "The name of the extension."
   },
   "extensionDescription": {

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extensionDescription": {
-    "message": "Audit your page images for SEO & performance: alt text, dimensions, file size, next-gen formats, lazy loading and LCP.",
+    "message": "Audita las imágenes de tu página: alt, dimensiones, tamaño, formatos modernos, carga diferida y LCP.",
     "description": "The description of the extension shown in the Chrome Web Store."
   }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "Oxyplug - Technical SEO Audit",
+    "message": "Oxyplug - Image Audit",
     "description": "The name of the extension."
   },
   "extensionDescription": {

--- a/_locales/fa/messages.json
+++ b/_locales/fa/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "Oxyplug - Technical SEO Audit",
+    "message": "Oxyplug - Image Audit",
     "description": "The name of the extension."
   },
   "extensionDescription": {

--- a/_locales/fa/messages.json
+++ b/_locales/fa/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extensionDescription": {
-    "message": "Audit your page images for SEO & performance: alt text, dimensions, file size, next-gen formats, lazy loading and LCP.",
+    "message": "تصاویر صفحه خود را بررسی کنید: متن جایگزین، ابعاد، حجم فایل، فرمت‌های نوین، بارگذاری تنبل و LCP.",
     "description": "The description of the extension shown in the Chrome Web Store."
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extensionDescription": {
-    "message": "Audit your page images for SEO & performance: alt text, dimensions, file size, next-gen formats, lazy loading and LCP.",
+    "message": "Auditez les images de votre page : alt, dimensions, taille, formats next-gen, lazy-loading et LCP.",
     "description": "The description of the extension shown in the Chrome Web Store."
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "Oxyplug - Technical SEO Audit",
+    "message": "Oxyplug - Image Audit",
     "description": "The name of the extension."
   },
   "extensionDescription": {

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -1,0 +1,10 @@
+{
+  "extensionName": {
+    "message": "Oxyplug - Technical SEO Audit",
+    "description": "The name of the extension."
+  },
+  "extensionDescription": {
+    "message": "अपने पेज की इमेज ऑडिट करें: alt, आकार, फ़ाइल साइज़, नेक्स्ट-जेन फ़ॉर्मैट, लेज़ी-लोडिंग और LCP।",
+    "description": "The description of the extension shown in the Chrome Web Store."
+  }
+}

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "Oxyplug - Technical SEO Audit",
+    "message": "Oxyplug - Image Audit",
     "description": "The name of the extension."
   },
   "extensionDescription": {

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "Oxyplug - Technical SEO Audit",
+    "message": "Oxyplug - Image Audit",
     "description": "The name of the extension."
   },
   "extensionDescription": {

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extensionDescription": {
-    "message": "Audit your page images for SEO & performance: alt text, dimensions, file size, next-gen formats, lazy loading and LCP.",
+    "message": "Analizza le immagini della tua pagina: alt, dimensioni, peso, formati next-gen, lazy loading e LCP.",
     "description": "The description of the extension shown in the Chrome Web Store."
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "Oxyplug - Technical SEO Audit",
+    "message": "Oxyplug - Image Audit",
     "description": "The name of the extension."
   },
   "extensionDescription": {

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extensionDescription": {
-    "message": "Audit your page images for SEO & performance: alt text, dimensions, file size, next-gen formats, lazy loading and LCP.",
+    "message": "ページ画像を監査：alt、サイズ、ファイルサイズ、次世代フォーマット、遅延読み込み、LCP。",
     "description": "The description of the extension shown in the Chrome Web Store."
   }
 }

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extensionDescription": {
-    "message": "Audit your page images for SEO & performance: alt text, dimensions, file size, next-gen formats, lazy loading and LCP.",
+    "message": "페이지 이미지 점검: alt, 크기, 파일 용량, 차세대 포맷, 지연 로딩, LCP.",
     "description": "The description of the extension shown in the Chrome Web Store."
   }
 }

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "Oxyplug - Technical SEO Audit",
+    "message": "Oxyplug - Image Audit",
     "description": "The name of the extension."
   },
   "extensionDescription": {

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "Oxyplug - Technical SEO Audit",
+    "message": "Oxyplug - Image Audit",
     "description": "The name of the extension."
   },
   "extensionDescription": {

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extensionDescription": {
-    "message": "Audit your page images for SEO & performance: alt text, dimensions, file size, next-gen formats, lazy loading and LCP.",
+    "message": "Audite as imagens da sua página: alt, dimensões, tamanho, formatos modernos, lazy loading e LCP.",
     "description": "The description of the extension shown in the Chrome Web Store."
   }
 }

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extensionDescription": {
-    "message": "Audit your page images for SEO & performance: alt text, dimensions, file size, next-gen formats, lazy loading and LCP.",
+    "message": "Аудит изображений страницы: alt, размеры, вес файла, форматы нового поколения, отложенная загрузка и LCP.",
     "description": "The description of the extension shown in the Chrome Web Store."
   }
 }

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "Oxyplug - Technical SEO Audit",
+    "message": "Oxyplug - Image Audit",
     "description": "The name of the extension."
   },
   "extensionDescription": {

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extensionDescription": {
-    "message": "Audit your page images for SEO & performance: alt text, dimensions, file size, next-gen formats, lazy loading and LCP.",
+    "message": "Sayfa görsellerinizi denetleyin: alt metni, boyut, dosya boyutu, yeni nesil formatlar, lazy-loading ve LCP.",
     "description": "The description of the extension shown in the Chrome Web Store."
   }
 }

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "Oxyplug - Technical SEO Audit",
+    "message": "Oxyplug - Image Audit",
     "description": "The name of the extension."
   },
   "extensionDescription": {

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "Oxyplug - Technical SEO Audit",
+    "message": "Oxyplug - Image Audit",
     "description": "The name of the extension."
   },
   "extensionDescription": {

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extensionDescription": {
-    "message": "Audit your page images for SEO & performance: alt text, dimensions, file size, next-gen formats, lazy loading and LCP.",
+    "message": "审计页面图片：alt 文本、尺寸、文件大小、新一代格式、懒加载和 LCP。",
     "description": "The description of the extension shown in the Chrome Web Store."
   }
 }

--- a/assets/js/audit.js
+++ b/assets/js/audit.js
@@ -91,8 +91,11 @@ class Audit {
               imgLoaded = true;
             }
 
-            while (imgLoaded === false) {
+            // Cap the wait so a cached/never-resolving image can't hang the audit.
+            let waitTries = 0;
+            while (imgLoaded === false && waitTries < 5) {
               await Common.wait(1000);
+              waitTries++;
             }
           }
 
@@ -546,7 +549,7 @@ class Audit {
         }
 
         const extension = img.src.split('.').pop().toLowerCase();
-        if (['wepb', 'avif'].includes(extension) || extension.length > 4) {
+        if (['webp', 'avif'].includes(extension) || extension.length > 4) {
           return resolve(true);
         }
 
@@ -1137,7 +1140,7 @@ class Audit {
         const observer = new IntersectionObserver((entries) => {
           entries.forEach((entry) => {
             const img = entry.target;
-            const spanX = img.nextSibling;
+            const spanX = img.nextElementSibling;
 
             // Check if it is visible
             if (entry.isIntersecting) {
@@ -1182,7 +1185,7 @@ class Audit {
         const spanXs = await Common.getElements('.oxyplug-tech-seo-highlight:not(.positioned)');
         for (const spanX of spanXs) {
           spanX.classList.add('positioned');
-          const img = spanX.previousSibling;
+          const img = spanX.previousElementSibling;
           if (spanX && img) {
             applyStyles(spanX, img);
             observer.observe(img);

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -1,6 +1,7 @@
 class Common {
   static hostLearnMores = [];
   static learnMores;
+  static port = null;
 
   /**
    * Make modal actions
@@ -146,99 +147,89 @@ class Common {
    * @returns {Promise<unknown>}
    */
   static async getLocalStorage(key) {
-    return new Promise((resolve) => {
-      chrome.storage.local.get(key, resolve);
-    })
-      .then(response => {
-        return response[key];
-      })
-      .catch(() => {
-        return null
-      });
-  };
+    try {
+      const response = await chrome.storage.local.get(key);
+      return response[key];
+    } catch (error) {
+      console.log(error);
+      return null;
+    }
+  }
 
   /**
    * Set local storage
    * @param object
-   * @returns {Promise<unknown>}
+   * @returns {Promise<boolean>}
    */
   static async setLocalStorage(object) {
-    return new Promise((resolve, reject) => {
-      chrome.storage.local.set(object, () => {
-        if (chrome.runtime.lastError) {
-          reject(chrome.runtime.lastError);
-        } else {
-          resolve();
-        }
-      });
-    })
-      .then(() => {
-        return true;
-      })
-      .catch(() => {
-        return false
-      });
-  };
+    try {
+      await chrome.storage.local.set(object);
+      return true;
+    } catch (error) {
+      console.log(error);
+      return false;
+    }
+  }
 
   /**
    * Get element
    * @param query
-   * @returns {Promise<unknown>}
+   * @returns {Promise<Element|null>}
    */
   static async getElement(query) {
-    return new Promise(async (resolve, reject) => {
-      try {
-        const element = await document.querySelector(query);
-        resolve(element);
-      } catch (error) {
-        console.log(error);
-        reject(error);
-      }
-    })
-      .then((response) => {
-        return response;
-      });
-  };
+    try {
+      return document.querySelector(query);
+    } catch (error) {
+      console.log(error);
+      return null;
+    }
+  }
 
   /**
    * Get elements
    * @param query
-   * @returns {Promise<unknown>}
+   * @returns {Promise<NodeListOf<Element>|Array>}
    */
   static async getElements(query) {
-    return new Promise(async (resolve, reject) => {
-      try {
-        const elements = await document.querySelectorAll(query);
-        resolve(elements);
-      } catch (error) {
-        console.log(error);
-        reject(error)
-      }
-    });
-  };
+    try {
+      return document.querySelectorAll(query);
+    } catch (error) {
+      console.log(error);
+      return [];
+    }
+  }
 
   /**
    * Get current tab
-   * @returns {Promise<chrome.tabs.Tab>}
+   * @returns {Promise<chrome.tabs.Tab|false>}
    */
   static async getCurrentTab() {
-    return new Promise(async (resolve, reject) => {
-      try {
-        const queryOptions = {active: true, currentWindow: true};
-        const [tab] = await chrome.tabs.query(queryOptions);
+    try {
+      const [tab] = await chrome.tabs.query({active: true, currentWindow: true});
+      return tab;
+    } catch (error) {
+      console.log(error);
+      return false;
+    }
+  }
 
-        resolve(tab);
+  /**
+   * Get (lazily creating) the shared messaging port and self-heal on disconnect.
+   * @returns {chrome.runtime.Port|null}
+   */
+  static getPort() {
+    if (!Common.port) {
+      try {
+        Common.port = chrome.runtime.connect({name: 'oxyplug-tech-seo-audit'});
+        Common.port.onDisconnect.addListener(() => {
+          Common.port = null;
+        });
       } catch (error) {
         console.log(error);
-        reject(false);
+        Common.port = null;
       }
-    })
-      .then(response => {
-        return response;
-      })
-      .catch(response => {
-        return response;
-      });
+    }
+    return Common.port;
   }
 
   /**
@@ -248,36 +239,35 @@ class Common {
    * @returns {Promise<void>}
    */
   static async log(text, currentHost = location.host) {
-    return new Promise(async (resolve, reject) => {
-      try {
-
-        const addLog = (logs, text) => {
-          // Add to localStorage
-          Common.setLocalStorage({logs});
-
-          // Send the log to popup
-          Common.port = chrome.runtime.connect({name: 'oxyplug-tech-seo-audit'});
-          Common.port.postMessage({log: text});
-        }
-
-        let logs = await Common.getLocalStorage('logs');
-        if (!logs || Object.keys(logs).length === 0) {
-          logs = {[currentHost]: [text]};
-          await addLog(logs, text);
-        } else if (!logs[currentHost]) {
-          logs[currentHost] = [text];
-          await addLog(logs, text);
-        } else if (!logs[currentHost].includes(text)) {
-          logs[currentHost].push(text);
-          await addLog(logs, text);
-        }
-
-        resolve();
-      } catch (error) {
-        console.log(error);
-        reject(error);
+    try {
+      let logs = await Common.getLocalStorage('logs');
+      if (!logs || Object.keys(logs).length === 0) {
+        logs = {[currentHost]: [text]};
+      } else if (!logs[currentHost]) {
+        logs[currentHost] = [text];
+      } else if (!logs[currentHost].includes(text)) {
+        logs[currentHost].push(text);
+      } else {
+        // Duplicate log line; nothing new to store or send.
+        return;
       }
-    });
+
+      // Add to localStorage
+      await Common.setLocalStorage({logs});
+
+      // Send the log to popup over the shared port
+      const port = Common.getPort();
+      if (port) {
+        try {
+          port.postMessage({log: text});
+        } catch (error) {
+          // Receiver gone; drop the port so the next log re-establishes it.
+          Common.port = null;
+        }
+      }
+    } catch (error) {
+      console.log(error);
+    }
   }
 
   /**
@@ -295,67 +285,60 @@ class Common {
 
   /**
    * Get learn mores
-   * @returns {Promise<unknown>}
+   * @returns {Promise<void>}
    */
   static async setLearnMores(host) {
-    return new Promise(resolve => {
-      if (!Common.hostLearnMores || !Common.hostLearnMores[host]) {
-        const utmLink = `https://www.oxyplug.com/docs/oxy-seo-audit/audit-definitions/?utm_source=${host}&utm_medium=chrome-extension&utm_campaign=`;
-        Common.learnMores = Common.hostLearnMores[host] = {
-          'utm-link': utmLink,
-          'issues': {
-            'loadFailsIssue': {
-              'load-fails': "The image fails to load with http status code of X.",
-            },
-            'srcIssue': {
-              'src': "Without src attribute.",
-            },
-            'altIssue': {
-              'alt': "Without alt attribute.",
-              'alt-length': "The alt attribute length is more than X characters.",
-            },
-            'widthIssue': {
-              'width': "Without width attribute.",
-            },
-            'heightIssue': {
-              'height': "Without height attribute.",
-            },
-            'renderedSizeIssue': {
-              'rendered-size': "The rendered image dimensions don't equal the original image dimensions.",
-            },
-            'aspectRatioIssue': {
-              'aspect-ratio': "The aspect-ratio of the rendered image doesn't equal the aspect-ratio of the original image.",
-            },
-            'filesizeIssue': {
-              'filesize': "The image filesize is bigger than X KB.",
-            },
-            'nxIssue': {
-              'nx': "No 2x image found for DPR 2 devices.",
-            },
-            'nextGenFormatsIssue': {
-              'next-gen-formats': "The next-gen (WebP, AVIF) is not provided.",
-            },
-            'lazyLoadIssue': {
-              'lazy-load': "The loading attribute doesn't equal `lazy`.",
-              'eager-load': "The loading attribute of LCP image doesn't equal `eager`.",
-            },
-            'preloadLcpIssue': {
-              'lcp-preload': "The LCP (Image) is not preloaded with link tag.",
-            },
-            'lcpIssue': {
-              'lcp': "The LCP shows the largest image above the fold.",
-            },
-            'decodingIssue': {
-              'decoding': "Having `decoding=\"sync\"` for LCP image is recommended.",
-            },
-          }
-        };
-      }
-      resolve();
-    })
-      .catch(error => {
-        console.log(error);
-        return error;
-      });
+    if (!Common.hostLearnMores || !Common.hostLearnMores[host]) {
+      const utmLink = `https://www.oxyplug.com/docs/oxy-seo-audit/audit-definitions/?utm_source=${host}&utm_medium=chrome-extension&utm_campaign=`;
+      Common.learnMores = Common.hostLearnMores[host] = {
+        'utm-link': utmLink,
+        'issues': {
+          'loadFailsIssue': {
+            'load-fails': "The image fails to load with http status code of X.",
+          },
+          'srcIssue': {
+            'src': "Without src attribute.",
+          },
+          'altIssue': {
+            'alt': "Without alt attribute.",
+            'alt-length': "The alt attribute length is more than X characters.",
+          },
+          'widthIssue': {
+            'width': "Without width attribute.",
+          },
+          'heightIssue': {
+            'height': "Without height attribute.",
+          },
+          'renderedSizeIssue': {
+            'rendered-size': "The rendered image dimensions don't equal the original image dimensions.",
+          },
+          'aspectRatioIssue': {
+            'aspect-ratio': "The aspect-ratio of the rendered image doesn't equal the aspect-ratio of the original image.",
+          },
+          'filesizeIssue': {
+            'filesize': "The image filesize is bigger than X KB.",
+          },
+          'nxIssue': {
+            'nx': "No 2x image found for DPR 2 devices.",
+          },
+          'nextGenFormatsIssue': {
+            'next-gen-formats': "The next-gen (WebP, AVIF) is not provided.",
+          },
+          'lazyLoadIssue': {
+            'lazy-load': "The loading attribute doesn't equal `lazy`.",
+            'eager-load': "The loading attribute of LCP image doesn't equal `eager`.",
+          },
+          'preloadLcpIssue': {
+            'lcp-preload': "The LCP (Image) is not preloaded with link tag.",
+          },
+          'lcpIssue': {
+            'lcp': "The LCP shows the largest image above the fold.",
+          },
+          'decodingIssue': {
+            'decoding': "Having `decoding=\"sync\"` for LCP image is recommended.",
+          },
+        }
+      };
+    }
   }
 }

--- a/assets/js/content-script.js
+++ b/assets/js/content-script.js
@@ -4,6 +4,8 @@ class ContentScript {
   static scrollables = [];
   static scrollableIndex = 0;
   static rtl = false;
+  // Safety backstop (px) applied only in "Unlimited" mode (max_scrolling === 0).
+  // In "Limited" mode the user-configured max (capped at 15000 in the popup) is used instead.
   static oxyplugScrollLimit = 50000;
 
   /**
@@ -646,7 +648,7 @@ class ContentScript {
       try {
         const spanXs = await Common.getElements('.oxyplug-tech-seo-highlight');
         spanXs.forEach((spanX) => {
-          const img = spanX.previousSibling;
+          const img = spanX.previousElementSibling;
           if (img) {
             if (img.dataset && img.dataset.oxyplug_tech_i) {
               const i = img.dataset.oxyplug_tech_i;
@@ -882,8 +884,8 @@ class ContentScript {
           highlight.style.setProperty('color', XColorAll, 'important');
         });
 
-        if (el) {
-          const nextSibling = el.nextSibling;
+        const nextSibling = el ? el.nextElementSibling : null;
+        if (el && nextSibling) {
           nextSibling.classList.add('oxyplug-tech-seo-highlighted');
           let XColor = await Common.getLocalStorage('x_color');
           XColor = XColor ? XColor.toString() : '#ff0000';

--- a/assets/js/popup.js
+++ b/assets/js/popup.js
@@ -326,7 +326,7 @@ class Popup {
 
                       await Popup.loadList(request.issues);
                       await Popup.renameStart('Restart');
-                      Popup.stop.disable = false;
+                      Popup.stop.disabled = false;
                       Popup.purgeReload.disabled = false;
                       await Popup.highlightActiveUrl();
                       await Popup.highlightActiveFilter();
@@ -352,7 +352,7 @@ class Popup {
         });
 
         if (Popup.issues && Object.keys(Popup.issues).length) {
-          Popup.stop.disable = false;
+          Popup.stop.disabled = false;
         }
 
         // Navigation between the pages
@@ -456,7 +456,13 @@ class Popup {
         e.stopPropagation();
         if (!window.myWindow || window.myWindow.closed) {
           window.myWindow = window.open('');
-          myWindow.document.write(`<img src="${completeSrc}" />`);
+          if (window.myWindow) {
+            // Build the node directly instead of document.write to avoid
+            // injecting markup from an untrusted (page-derived) src.
+            const img = window.myWindow.document.createElement('img');
+            img.src = completeSrc;
+            window.myWindow.document.body.appendChild(img);
+          }
         } else {
           window.myWindow.focus();
         }

--- a/background.js
+++ b/background.js
@@ -1,131 +1,116 @@
 class Background {
   /**
+   * Record the filesize (or load failure) for a single image request.
+   * Reads the existing maps from storage and merges into them so previously
+   * captured images are preserved (MV3 service workers are short-lived and
+   * keep no in-memory state between events).
    * @param details
    * @returns {Promise<void>}
    */
   static async setFileSizes(details) {
-    let loadFails = {};
-    let imageFilesizes = {};
-    Background.currentTab = await Background.getCurrentTab();
+    const currentTab = await Background.getCurrentTab();
 
-    if (!Background.currentTab) {
-      setTimeout(() => {
-        Background.setFileSizes(details);
-      }, 1000);
-    } else if (details.tabId !== Background.currentTab.id) {
-      // Image loaded
-      if (details.statusCode === 200) {
-        // Unset it if it was previously failed to load
-        if (loadFails[details.url]) {
-          delete loadFails[details.url];
-          await Background.setLocalStorage({load_fails: loadFails});
-        }
+    // Only record images that belong to the tab currently being audited.
+    if (!currentTab || details.tabId !== currentTab.id) {
+      return;
+    }
 
-        // Do not add filesize if it has already been added
-        if (!imageFilesizes[details.url]) {
-          let filesize = 0;
+    const loadFails = (await Background.getLocalStorage('load_fails')) ?? {};
+    const imageFilesizes = (await Background.getLocalStorage('image_filesizes')) ?? {};
 
-          details.responseHeaders.forEach((item) => {
-            if (item.name.toLowerCase() === 'content-length') {
-              filesize = Number(item.value) / 1000;
-            }
-          });
-
-          // add filesize
-          imageFilesizes[details.url] = filesize;
-          await Background.setLocalStorage({image_filesizes: imageFilesizes});
-        }
-      } else {
-        if (imageFilesizes[details.url]) {
-          delete imageFilesizes[details.url];
-          await Background.setLocalStorage({image_filesizes: imageFilesizes});
-        }
-
-        loadFails[details.url] = details.statusCode;
+    // Image loaded
+    if (details.statusCode === 200) {
+      // Unset it if it was previously failed to load
+      if (loadFails[details.url]) {
+        delete loadFails[details.url];
         await Background.setLocalStorage({load_fails: loadFails});
       }
+
+      // Do not add filesize if it has already been added
+      if (!imageFilesizes[details.url]) {
+        let filesize = 0;
+
+        details.responseHeaders.forEach((item) => {
+          if (item.name.toLowerCase() === 'content-length') {
+            filesize = Number(item.value) / 1000;
+          }
+        });
+
+        // add filesize
+        imageFilesizes[details.url] = filesize;
+        await Background.setLocalStorage({image_filesizes: imageFilesizes});
+      }
+    } else {
+      if (imageFilesizes[details.url]) {
+        delete imageFilesizes[details.url];
+        await Background.setLocalStorage({image_filesizes: imageFilesizes});
+      }
+
+      loadFails[details.url] = details.statusCode;
+      await Background.setLocalStorage({load_fails: loadFails});
     }
   }
 
   /**
    * Get current tab
-   * @returns {Promise<unknown>}
+   * @returns {Promise<chrome.tabs.Tab|null>}
    */
   static async getCurrentTab() {
-    return new Promise(async (resolve, reject) => {
-      try {
-        const queryOptions = {active: true, currentWindow: true};
-        const [tab] = await chrome.tabs.query(queryOptions);
+    try {
+      const queryOptions = {active: true, currentWindow: true};
+      const [tab] = await chrome.tabs.query(queryOptions);
+      return tab ?? null;
+    } catch (error) {
+      console.log(error);
+      return null;
+    }
+  }
 
-        resolve(tab);
-      } catch (error) {
-        console.log(error);
-        reject(false);
-      }
-    })
-      .then(response => {
-        return response;
-      })
-      .catch(response => {
-        return response;
-      });
+  /**
+   * Get local storage
+   * @param key
+   * @returns {Promise<unknown>}
+   */
+  static async getLocalStorage(key) {
+    try {
+      const response = await chrome.storage.local.get(key);
+      return response[key];
+    } catch (error) {
+      console.log(error);
+      return null;
+    }
   }
 
   /**
    * Set local storage
    * @param object
-   * @returns {Promise<unknown>}
+   * @returns {Promise<boolean>}
    */
   static async setLocalStorage(object) {
-    return new Promise((resolve, reject) => {
-      chrome.storage.local.set(object, () => {
-        if (chrome.runtime.lastError) {
-          reject(chrome.runtime.lastError);
-        } else {
-          resolve();
-        }
-      });
-    })
-      .then(() => {
-        return true;
-      })
-      .catch(() => {
-        return false
-      });
-  };
-
-  /**
-   * @returns {Promise<void>}
-   */
-  static async init() {
-    return new Promise(async (resolve, reject) => {
-      try {
-        // Get current tab
-        Background.currentTab = await Background.getCurrentTab();
-
-        // Audit
-        chrome.webRequest.onHeadersReceived.addListener(async (details) => {
-            setTimeout(() => {
-              Background.setFileSizes(details);
-            }, 1000);
-          },
-          {urls: ["<all_urls>"], types: ['image']},
-          ['responseHeaders']
-        );
-
-        resolve();
-      } catch (error) {
-        console.log(error);
-        reject(error);
-      }
-    });
-  };
+    try {
+      await chrome.storage.local.set(object);
+      return true;
+    } catch (error) {
+      console.log(error);
+      return false;
+    }
+  }
 }
 
-Background.init()
-  .then(() => {
-    console.log('Background init');
-  })
-  .catch(() => {
-    console.log('Background error')
-  });
+/**
+ * Register the listener synchronously at the top level so it is re-attached
+ * every time the service worker is (re)started by the browser. The work is
+ * delayed slightly to give the response a chance to settle before the headers
+ * are read.
+ */
+chrome.webRequest.onHeadersReceived.addListener(
+  (details) => {
+    setTimeout(() => {
+      Background.setFileSizes(details);
+    }, 1000);
+  },
+  {urls: ['<all_urls>'], types: ['image']},
+  ['responseHeaders']
+);
+
+console.log('Background init');

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "name": "Oxyplug - Technical SEO Audit",
+  "name": "__MSG_extensionName__",
   "version": "1.0.0",
   "action": {
     "default_icon": {
@@ -13,7 +13,7 @@
     "default_popup": "popup.html"
   },
   "default_locale": "en",
-  "description": "Find bugs on your page based on Google Lighthouse",
+  "description": "__MSG_extensionDescription__",
   "icons": {
     "16": "/assets/icons/16.png",
     "32": "/assets/icons/32.png",
@@ -44,12 +44,6 @@
   "background": {
     "service_worker": "background.js"
   },
-  "externally_connectable": {
-    "matches": [
-      "http://*/*",
-      "https://*/*"
-    ]
-  },
   "host_permissions": [
     "http://*/*",
     "https://*/*"
@@ -59,7 +53,6 @@
     "webRequest"
   ],
   "short_name": "Technical SEO",
-  "update_url": "https://www.oxyplug.com/extensions/Technical-SEO-Audit/update-info.xml",
   "web_accessible_resources": [
     {
       "resources": [

--- a/manifest.json
+++ b/manifest.json
@@ -52,7 +52,7 @@
     "storage",
     "webRequest"
   ],
-  "short_name": "Technical SEO",
+  "short_name": "Image Audit",
   "web_accessible_resources": [
     {
       "resources": [

--- a/popup.html
+++ b/popup.html
@@ -3,13 +3,13 @@
 <head>
   <link rel="stylesheet" href="assets/css/common.css">
   <link rel="stylesheet" href="assets/css/popup.css">
-  <title>Oxyplug - Technical SEO Audit</title>
+  <title>Oxyplug - Image Audit</title>
   <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
 </head>
 <body class="d-none">
 
 <div id="wrapper">
-  <h1 class="oxyplug-tech-seo-h1">Oxyplug - Technical SEO Audit</h1>
+  <h1 class="oxyplug-tech-seo-h1">Oxyplug - Image Audit</h1>
 
   <nav class="oxyplug-section">
     <button class="button button-active oxyplug-icon-home" data-target="home"></button>


### PR DESCRIPTION
Audit fixes
- Preserve background maps across requests by reading and merging storage
- Record only the audited tab (fixed inverted tab condition)
- Fix .wepb → .webp typo
- Register service-worker listener at top level and resolve tab per event
- Prevent infinite image reload waits by capping retries to 5

Security & permissions
- Remove externally_connectable configuration
- Remove update_url from manifest (Web Store compatibility)
- Replace document.write usage with createElement-based DOM construction
- Keep <all_urls> and webRequest permissions by design for page auditing and cross-origin content-length checks (requires store justification)

Code quality & maintainability
- Flatten safe Promise-constructor antipattern cases in common.js
- Wire extension i18n metadata through _locales/en/messages.json
- Fix Popup.stop.disable typo → disabled
- Document 50000 scroll limit as Unlimited-mode safety backstop
- Replace sibling traversal with nextElementSibling/previousElementSibling
- Reuse a shared self-healing Common.getPort() instead of one port per log line