### PR TITLE
docs: fill in store listing contact and privacy policy URLs

### DIFF
--- a/CHROMEWEBSTORE.md
+++ b/CHROMEWEBSTORE.md
@@ -38,7 +38,7 @@ Privacy:
 Your audit results and settings stay on your device. The extension does not collect, sell, or transmit your data to any server, and it has no analytics or tracking.
 
 Support:
-Questions or feedback? Visit https://oxyplug.com
+Questions or feedback? Visit https://www.oxyplug.com/contact-us/
 
 **Category** [REQUIRED]
 Developer Tools
@@ -108,8 +108,7 @@ documentation page in a new tab.
 ## Privacy Policy
 
 **Privacy Policy URL** [REQUIRED]
-<!-- Host PRIVACY_POLICY.md at a public URL (GitHub Pages works) and paste it here. -->
-_TODO: host PRIVACY_POLICY.md and add the live URL._
+https://github.com/Oxyplug/Oxyplug-Image-Audit/blob/main/PRIVACY_POLICY.md
 
 ## Distribution
 
@@ -122,13 +121,13 @@ _TODO: host PRIVACY_POLICY.md and add the live URL._
 Oxyplug
 
 **Contact Email** [REQUIRED]
-_TODO: add a monitored contact email (shown publicly on the listing)._
+support@oxyplug.com
 
 **Support URL / Email** [RECOMMENDED]
-https://oxyplug.com
+support@oxyplug.com
 
 **Homepage URL** [RECOMMENDED]
-https://oxyplug.com
+https://www.oxyplug.com/
 
 ## Version History
 

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -64,4 +64,4 @@ If this policy changes, the "Last updated" date above will be revised.
 
 ## Contact
 
-For questions about this policy, visit https://oxyplug.com.
+For questions about this policy, email support@oxyplug.com or visit https://www.oxyplug.com/.


### PR DESCRIPTION
Fill in the remaining Chrome Web Store listing metadata.

- Privacy Policy URL → live GitHub-hosted policy
- Contact + support email → support@oxyplug.com
- Homepage → https://www.oxyplug.com/
- Detailed-description support link → https://www.oxyplug.com/contact-us/
- Privacy policy contact section updated with the support email

Only screenshot filenames remain to be filled in (after capture).