### PR TITLE
feat(report): in-popup summary, thumbnails, richer modal + grouped Help tab

### DIFF
--- a/CHROMEWEBSTORE.md
+++ b/CHROMEWEBSTORE.md
@@ -33,6 +33,7 @@ How to use it:
 2. Click the Oxyplug - Image Audit icon.
 3. Press Start. The extension scrolls the page to trigger lazy images, then lists every issue it finds.
 4. Click any issue to jump to that image on the page. Use the filter tabs to focus on one issue type, exclude images you don't care about, or review your last 10 audits in History.
+5. Save or share your findings: export a full HTML report, export a CSV for spreadsheets, or copy a text summary. Every check also has a built-in definition and fix in the Help tab.
 
 Privacy:
 Your audit results and settings stay on your device. The extension does not collect, sell, or transmit your data to any server, and it has no analytics or tracking.
@@ -108,7 +109,9 @@ documentation page in a new tab.
 ## Privacy Policy
 
 **Privacy Policy URL** [REQUIRED]
-https://github.com/Oxyplug/Oxyplug-Image-Audit/blob/main/PRIVACY_POLICY.md
+https://www.oxyplug.com/docs/oxy-image-audit/privacy/
+<!-- Confirm this page is published and live before submitting. Fallback (already live):
+     https://github.com/Oxyplug/Oxyplug-Image-Audit/blob/main/PRIVACY_POLICY.md -->
 
 ## Distribution
 
@@ -133,7 +136,7 @@ https://www.oxyplug.com/
 
 | Version | Date | Changes | Status |
 |---------|------|---------|--------|
-| 1.0.0 | 2026-07-06 | Initial Chrome Web Store submission. | Draft |
+| 1.0.0 | 2026-07-06 | Initial Chrome Web Store submission. Includes on-page issue markers, filterable results, exportable HTML/CSV reports, copy-summary, a bundled Help page, exclusions, and audit history. | Draft |
 
 ## Review Notes
 

--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -152,6 +152,16 @@
   margin-right: 24px;
 }
 
+.oxyplug-modal-thumb {
+  display: block;
+  max-width: 120px;
+  max-height: 120px;
+  object-fit: contain;
+  border-radius: 3px;
+  margin: 0 0 10px;
+  background-color: var(--oxyplug-lightest-gray);
+}
+
 .oxyplug-modal-content ul {
   padding: 0;
   margin: 0;

--- a/assets/css/help.css
+++ b/assets/css/help.css
@@ -1,0 +1,125 @@
+html {
+  background-color: var(--oxyplug-lightest-gray);
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: Montserrat, system-ui, -apple-system, sans-serif;
+  font-weight: 500;
+  color: var(--oxyplug-darkest-gray);
+  line-height: 1.5;
+}
+
+.help-wrap {
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 32px 20px 48px;
+}
+
+.help-header {
+  background-color: var(--oxyplug-white-color);
+  border-radius: 8px;
+  padding: 24px 28px;
+  box-shadow: 0 1px 4px var(--oxyplug-alpha-black-3);
+  margin-bottom: 20px;
+}
+
+.help-header h1 {
+  margin: 0 0 6px;
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--oxyplug-blue);
+}
+
+.help-header p {
+  margin: 0;
+  color: var(--oxyplug-darker-gray);
+}
+
+.help-group {
+  display: inline-block;
+  margin: 24px 0 10px;
+  padding: 4px 16px;
+  border-radius: 999px;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--oxyplug-white-color);
+}
+
+.help-group.critical {
+  background-color: var(--oxyplug-red);
+}
+
+.help-group.warning {
+  background-color: var(--oxyplug-yellow);
+  color: var(--oxyplug-black);
+}
+
+.help-group.info {
+  background-color: var(--oxyplug-aqua);
+}
+
+.help-item {
+  background-color: var(--oxyplug-white-color);
+  border-radius: 8px;
+  padding: 16px 20px;
+  margin-bottom: 12px;
+  box-shadow: 0 1px 3px var(--oxyplug-alpha-black-3);
+  border-left: 4px solid var(--oxyplug-lighter-gray);
+}
+
+.help-item h3 {
+  margin: 0 0 6px;
+  font-size: 17px;
+  font-weight: 700;
+}
+
+.help-item .def {
+  margin: 0 0 8px;
+  color: var(--oxyplug-darkest-gray);
+}
+
+.help-item .fix {
+  margin: 0;
+  color: var(--oxyplug-darker-gray);
+}
+
+.help-item .fix b {
+  color: var(--oxyplug-green);
+}
+
+.help-item code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.9em;
+  background-color: var(--oxyplug-lightest-gray);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+section:nth-of-type(1) .help-item {
+  border-left-color: var(--oxyplug-red);
+}
+
+section:nth-of-type(2) .help-item {
+  border-left-color: var(--oxyplug-yellow);
+}
+
+section:nth-of-type(3) .help-item {
+  border-left-color: var(--oxyplug-aqua);
+}
+
+.help-footer {
+  margin-top: 28px;
+  text-align: center;
+}
+
+.help-footer a {
+  color: var(--oxyplug-blue);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.help-footer a:hover {
+  text-decoration: underline;
+}

--- a/assets/css/popup.css
+++ b/assets/css/popup.css
@@ -405,6 +405,66 @@ nav > a {
   opacity: 0.5;
 }
 
+#audit-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px;
+  margin: 8px 0;
+}
+
+.sum-grade {
+  font-weight: 700;
+  font-size: 0.95em;
+  padding: 3px 10px;
+  border-radius: 999px;
+  color: var(--oxyplug-white-color);
+}
+
+.sum-grade.perfect,
+.sum-grade.good {
+  background-color: var(--oxyplug-green);
+}
+
+.sum-grade.needs-work {
+  background-color: var(--oxyplug-yellow);
+  color: var(--oxyplug-black);
+}
+
+.sum-grade.poor {
+  background-color: var(--oxyplug-red);
+}
+
+.sum-chip {
+  font-size: 0.85em;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background-color: var(--oxyplug-lightest-gray);
+  color: var(--oxyplug-darker-gray);
+}
+
+.sum-chip.critical {
+  color: var(--oxyplug-red);
+}
+
+.sum-chip.warning {
+  color: var(--oxyplug-black);
+}
+
+.sum-chip.info {
+  color: var(--oxyplug-aqua);
+}
+
+.issue-thumb {
+  width: 28px;
+  height: 28px;
+  object-fit: cover;
+  border-radius: 3px;
+  margin-right: 6px;
+  vertical-align: middle;
+  background-color: var(--oxyplug-lightest-gray);
+}
+
 .info-box {
   background: var(--oxyplug-lightest-gray);
   border: 1px solid var(--oxyplug-lighter-gray);

--- a/assets/css/popup.css
+++ b/assets/css/popup.css
@@ -615,6 +615,57 @@ nav > a {
   text-decoration: none;
 }
 
+.learn-intro {
+  margin: 10px 0;
+  font-size: 0.95em;
+  line-height: 1.4;
+  color: var(--oxyplug-darker-gray);
+}
+
+.learn-group {
+  display: inline-block;
+  margin: 14px 0 2px;
+  padding: 2px 12px;
+  border-radius: 999px;
+  font-size: 0.95em;
+  font-weight: 700;
+  color: var(--oxyplug-white-color);
+}
+
+.learn-group.critical {
+  background-color: var(--oxyplug-red);
+}
+
+.learn-group.warning {
+  background-color: var(--oxyplug-yellow);
+  color: var(--oxyplug-black);
+}
+
+.learn-group.info {
+  background-color: var(--oxyplug-aqua);
+}
+
+#learn .learn-list {
+  margin: 4px 0 0;
+  padding-left: 20px;
+}
+
+#learn .learn-list li {
+  margin-bottom: 6px;
+  font-size: 0.9em;
+  line-height: 1.4;
+}
+
+.learn-more-link {
+  margin: 16px 0 4px;
+}
+
+.learn-more-link a {
+  color: var(--oxyplug-blue);
+  font-weight: 700;
+  text-decoration: none;
+}
+
 /* Info/LearnMore Page Ends Here */
 
 /* History Page Starts Here */

--- a/assets/js/audit.js
+++ b/assets/js/audit.js
@@ -964,7 +964,7 @@ class Audit {
 
               const messages = Audit.issues[className] ? Audit.issues[className].messages : [];
               const issueTypes = Audit.issues[className] ? Audit.issues[className].issueTypes : [];
-              await Common.showIssues(messages, issueTypes);
+              await Common.showIssues(messages, issueTypes, 'content', img.src);
             });
 
             // Put spanX after img

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -59,7 +59,7 @@ class Common {
    * @param caller
    * @returns {Promise<void>}
    */
-  static async showIssues(messages, issueTypes, caller = 'content') {
+  static async showIssues(messages, issueTypes, caller = 'content', url = null) {
     const messageId = 'oxyplug-modal-message';
     const sectionId = 'oxyplug-tech-seo-section';
     let shadowWrap = await Common.getElement(`#${sectionId}`);
@@ -90,8 +90,26 @@ class Common {
     }
 
     const messageModal = shadowWrap.shadowRoot.getElementById(messageId);
-    const ul = messageModal.querySelector('.oxyplug-modal-content ul');
+    const content = messageModal.querySelector('.oxyplug-modal-content');
+    const ul = content.querySelector('ul');
     ul.innerHTML = '';
+
+    // Show a thumbnail of the audited image at the top of the report
+    let thumb = content.querySelector('.oxyplug-modal-thumb');
+    if (url && /^https?:|^data:image/i.test(url)) {
+      if (!thumb) {
+        thumb = document.createElement('img');
+        thumb.className = 'oxyplug-modal-thumb';
+        content.insertBefore(thumb, ul);
+      }
+      thumb.style.display = '';
+      thumb.onerror = () => {
+        thumb.style.display = 'none';
+      };
+      thumb.src = url;
+    } else if (thumb) {
+      thumb.style.display = 'none';
+    }
     for (const message of messages) {
       const index = messages.indexOf(message);
       const li = document.createElement('li');

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -146,7 +146,7 @@ class Common {
           await Common.setLearnMores(host);
           let utmLink = Common.learnMores['utm-link'];
           const [[firstKey]] = Object.entries(Common.learnMores['issues'][id]);
-          const href = `${utmLink}${firstKey}#${firstKey}`;
+          const href = `${utmLink}${firstKey}`;
           const learnMore = `<a class="oxyplug-icon-info" href="${href}" target="_blank"></a>`;
           li.append(span, message);
           li.insertAdjacentHTML('beforeend', learnMore);
@@ -307,7 +307,7 @@ class Common {
    */
   static async setLearnMores(host) {
     if (!Common.hostLearnMores || !Common.hostLearnMores[host]) {
-      const utmLink = `https://www.oxyplug.com/docs/oxy-seo-audit/audit-definitions/?utm_source=${host}&utm_medium=chrome-extension&utm_campaign=`;
+      const utmLink = `https://www.oxyplug.com/docs/oxy-image-audit/?utm_source=${host}&utm_medium=chrome-extension&utm_campaign=`;
       Common.learnMores = Common.hostLearnMores[host] = {
         'utm-link': utmLink,
         'issues': {

--- a/assets/js/content-script.js
+++ b/assets/js/content-script.js
@@ -35,7 +35,8 @@ class ContentScript {
             } else if (request.messages) {
               await ContentScript.postMessage({
                 showIssues: request.messages,
-                issueTypes: request.issueTypes
+                issueTypes: request.issueTypes,
+                url: request.url
               });
             } else if (request.newXColor) {
               await ContentScript.setXColor(request);

--- a/assets/js/popup.js
+++ b/assets/js/popup.js
@@ -1225,7 +1225,6 @@ class Popup {
   static async loadLearnMore() {
     await Common.setLearnMores(Popup.currentHost);
     const learnEl = await Common.getElement('#learn');
-    const utmLink = Common.learnMores['utm-link'];
     const issues = Common.learnMores['issues'];
 
     // Clear any previously rendered summary (keep the heading)
@@ -1269,7 +1268,7 @@ class Popup {
     const moreP = document.createElement('p');
     moreP.className = 'learn-more-link';
     const a = document.createElement('a');
-    a.href = `${utmLink}all`;
+    a.href = chrome.runtime.getURL('help.html');
     a.target = '_blank';
     a.innerText = 'See full definitions & fixes →';
     moreP.append(a);

--- a/assets/js/popup.js
+++ b/assets/js/popup.js
@@ -345,7 +345,7 @@ class Popup {
                       // Fill issues history
                       await Popup.loadIssuesHistoryList(request.allIssues);
                     } else if (request.showIssues) {
-                      await Common.showIssues(request.showIssues, request.issueTypes, 'popup');
+                      await Common.showIssues(request.showIssues, request.issueTypes, 'popup', request.url);
                     }
                   }
 
@@ -529,8 +529,28 @@ class Popup {
    * @returns {Promise<void>}
    */
   static async postMessage(data) {
-    Popup.port = chrome.tabs.connect(Popup.currentTab.id, {name: 'oxyplug-tech-seo-audit'});
-    Popup.port.postMessage(data);
+    try {
+      Popup.port = chrome.tabs.connect(Popup.currentTab.id, {name: 'oxyplug-tech-seo-audit'});
+      Popup.port.onDisconnect.addListener(async () => {
+        // A disconnect with lastError set means the content script isn't in this
+        // tab (e.g. the page was already open before the extension loaded).
+        // Checking lastError also clears the "Unchecked runtime.lastError" warning.
+        if (chrome.runtime.lastError) {
+          try {
+            await Common.setLocalStorage({is_processing: false, stopped: true, processingOn: null});
+            await Popup.processingState(false);
+            await Popup.addToLogsList('Could not reach this page. Please reload it (F5) and try again.');
+            const logsBox = await Common.getElement('#progress-logs');
+            if (logsBox) logsBox.style.display = 'block';
+          } catch (error) {
+            console.log(error);
+          }
+        }
+      });
+      Popup.port.postMessage(data);
+    } catch (error) {
+      console.log(error);
+    }
   }
 
   /**
@@ -700,8 +720,39 @@ class Popup {
         issueList.innerHTML = '';
       }
 
+      await Popup.renderSummary(null);
+
       resolve();
     });
+  }
+
+  /**
+   * Render the at-a-glance audit summary header inside the popup.
+   * @param issues
+   * @returns {Promise<void>}
+   */
+  static async renderSummary(issues) {
+    const el = await Common.getElement('#audit-summary');
+    if (!el) return;
+
+    if (!issues || !issues.audit) {
+      el.classList.add('d-none');
+      el.innerHTML = '';
+      return;
+    }
+
+    const summary = await Report.summarize(issues);
+    const gradeClass = summary.grade.toLowerCase().replace(/\s+/g, '-');
+    const chip = (value, label, cls = '') => `<span class="sum-chip ${cls}"><b>${value}</b> ${label}</span>`;
+
+    const chips = [chip(summary.imagesWithIssues, 'imgs')];
+    if (summary.critical) chips.push(chip(summary.critical, 'critical', 'critical'));
+    if (summary.warning) chips.push(chip(summary.warning, 'warning', 'warning'));
+    if (summary.info) chips.push(chip(summary.info, 'info', 'info'));
+    if (summary.weightKB) chips.push(chip(summary.weightKB, 'KB'));
+
+    el.innerHTML = `<span class="sum-grade ${gradeClass}">${summary.grade}</span>${chips.join('')}`;
+    el.classList.remove('d-none');
   }
 
   /**
@@ -712,14 +763,24 @@ class Popup {
   static async loadList(issues) {
     return new Promise(async (resolve, reject) => {
       try {
+        // Render the at-a-glance summary header
+        await Popup.renderSummary(issues);
+
         const auditPage = issues.audit.page;
         const issuesCount = issues.count;
         issues = issues.issues;
         const issuesArray = Object.keys(issues);
 
         if (issuesArray.length) {
-          // Sort
-          issues = issuesArray.sort().reduce((obj, key) => {
+          // Sort by severity (critical first), then by key for stable order
+          const severityRank = {critical: 0, warning: 1, info: 2};
+          const rankOf = (key) => (issues[key].issueTypes || []).reduce(
+            (min, type) => Math.min(min, severityRank[Report.severityOf(type)]), 3
+          );
+          issues = issuesArray.sort((a, b) => {
+            const diff = rankOf(a) - rankOf(b);
+            return diff !== 0 ? diff : a.localeCompare(b);
+          }).reduce((obj, key) => {
             obj[key] = issues[key];
             return obj;
           }, {});
@@ -766,9 +827,20 @@ class Popup {
 
               Popup.postMessage({
                 messages: details.messages,
-                issueTypes: details.issueTypes
+                issueTypes: details.issueTypes,
+                url: details.url
               });
             };
+
+            // Thumbnail of the image (hidden if it fails to load)
+            if (/^https?:|^data:image/i.test(details.url)) {
+              const thumb = document.createElement('img');
+              thumb.className = 'issue-thumb';
+              thumb.src = details.url;
+              thumb.loading = 'lazy';
+              thumb.addEventListener('error', () => thumb.remove());
+              li.append(thumb);
+            }
 
             const span = document.createElement('span');
             span.innerText = decodeURI(srcExcerpt);

--- a/assets/js/popup.js
+++ b/assets/js/popup.js
@@ -1224,26 +1224,56 @@ class Popup {
    */
   static async loadLearnMore() {
     await Common.setLearnMores(Popup.currentHost);
-    const learnMoreList = await Common.getElement('#learn ul');
+    const learnEl = await Common.getElement('#learn');
     const utmLink = Common.learnMores['utm-link'];
-    for (const [_, messageObject] of Object.entries(Common.learnMores['issues'])) {
-      for (const [key, message] of Object.entries(messageObject)) {
+    const issues = Common.learnMores['issues'];
 
-        // li
-        const li = document.createElement('li');
-        li.innerText = message + ' ';
+    // Clear any previously rendered summary (keep the heading)
+    learnEl.querySelectorAll(':scope > :not(h2)').forEach((el) => el.remove());
 
-        // a
-        const a = document.createElement('a');
-        a.href = `${utmLink}${key}#${key}`;
-        a.target = '_blank';
-        a.innerText = 'Learn More';
+    // Intro
+    const intro = document.createElement('p');
+    intro.className = 'learn-intro';
+    intro.innerText = 'Oxyplug checks each image on the page for these SEO & performance issues, grouped by priority:';
+    learnEl.append(intro);
 
-        // append
-        li.append(a);
-        learnMoreList.append(li);
-      }
+    // Group the issue types by severity
+    const groups = {critical: [], warning: [], info: []};
+    for (const issueType of Object.keys(issues)) {
+      groups[Report.severityOf(issueType)].push(issueType);
     }
+
+    const groupLabels = {critical: 'Critical', warning: 'Warning', info: 'Info'};
+    for (const severity of ['critical', 'warning', 'info']) {
+      if (!groups[severity].length) continue;
+
+      const heading = document.createElement('h3');
+      heading.className = `learn-group ${severity}`;
+      heading.innerText = groupLabels[severity];
+      learnEl.append(heading);
+
+      const ul = document.createElement('ul');
+      ul.className = 'learn-list';
+      for (const issueType of groups[severity]) {
+        const li = document.createElement('li');
+        const strong = document.createElement('strong');
+        strong.innerText = Report.labelOf(issueType);
+        const definition = Object.values(issues[issueType]).join(' ');
+        li.append(strong, document.createTextNode(' — ' + definition));
+        ul.append(li);
+      }
+      learnEl.append(ul);
+    }
+
+    // Single link to the full documentation
+    const moreP = document.createElement('p');
+    moreP.className = 'learn-more-link';
+    const a = document.createElement('a');
+    a.href = `${utmLink}all`;
+    a.target = '_blank';
+    a.innerText = 'See full definitions & fixes →';
+    moreP.append(a);
+    learnEl.append(moreP);
   }
 
   /**

--- a/help.html
+++ b/help.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Oxyplug — Image Audit · Definitions &amp; Fixes</title>
+  <link rel="stylesheet" href="assets/css/common.css">
+  <link rel="stylesheet" href="assets/css/help.css">
+</head>
+<body>
+<div class="help-wrap">
+  <header class="help-header">
+    <h1>Image Audit — Definitions &amp; Fixes</h1>
+    <p>What each check means and how to fix it. Issues are grouped by priority.</p>
+  </header>
+
+  <main>
+    <section>
+      <h2 class="help-group critical">Critical</h2>
+
+      <article class="help-item">
+        <h3>Load fail</h3>
+        <p class="def">The image fails to load, returning a non-200 HTTP status (for example 404 Not Found or 403 Forbidden). A broken image hurts both users and crawlers.</p>
+        <p class="fix"><b>Fix:</b> Correct the <code>src</code> URL or restore the missing file. Also check that paths inside <code>srcset</code> contain no spaces, which can break loading.</p>
+      </article>
+
+      <article class="help-item">
+        <h3>Missing / empty src</h3>
+        <p class="def">The <code>&lt;img&gt;</code> has no <code>src</code> attribute, or the <code>src</code> is empty, so no image is shown.</p>
+        <p class="fix"><b>Fix:</b> Give every content image a valid <code>src</code>. If the image is loaded via a framework, make sure the value is populated before render.</p>
+      </article>
+
+      <article class="help-item">
+        <h3>Alt text</h3>
+        <p class="def">The <code>alt</code> attribute is missing, empty, or longer than your configured limit. Alt text describes the image for screen readers and search engines.</p>
+        <p class="fix"><b>Fix:</b> Add concise, descriptive alt text (keep it under your max, e.g. ~125 characters). For purely decorative images, use an empty <code>alt=""</code> so assistive tech skips them.</p>
+      </article>
+
+      <article class="help-item">
+        <h3>Missing width</h3>
+        <p class="def">The image has no <code>width</code> attribute, so the browser can't reserve space before it loads.</p>
+        <p class="fix"><b>Fix:</b> Set an explicit <code>width</code> (together with <code>height</code>). This reserves layout space and prevents Cumulative Layout Shift (CLS).</p>
+      </article>
+
+      <article class="help-item">
+        <h3>Missing height</h3>
+        <p class="def">The image has no <code>height</code> attribute, so the browser can't reserve space before it loads.</p>
+        <p class="fix"><b>Fix:</b> Set an explicit <code>height</code> (together with <code>width</code>), or define an <code>aspect-ratio</code> in CSS, to avoid layout shift.</p>
+      </article>
+
+      <article class="help-item">
+        <h3>Rendered size</h3>
+        <p class="def">The image's displayed (rendered) dimensions differ from its real (natural) dimensions — you may be shipping far more pixels than are shown.</p>
+        <p class="fix"><b>Fix:</b> Export the image close to its displayed size, and use a responsive <code>srcset</code> with <code>sizes</code> so each device downloads an appropriately sized file.</p>
+      </article>
+
+      <article class="help-item">
+        <h3>Aspect ratio</h3>
+        <p class="def">The rendered aspect ratio differs from the source image's aspect ratio, which stretches or squashes the image.</p>
+        <p class="fix"><b>Fix:</b> Keep the displayed width:height matching the source, or use <code>object-fit: cover</code> / <code>contain</code> to fit without distortion.</p>
+      </article>
+
+      <article class="help-item">
+        <h3>File size</h3>
+        <p class="def">The image file is larger than your configured limit, slowing the page down.</p>
+        <p class="fix"><b>Fix:</b> Compress the image, resize it to the dimensions actually used, and prefer next-gen formats (WebP/AVIF) which are much smaller at the same quality.</p>
+      </article>
+
+      <article class="help-item">
+        <h3>No 2x</h3>
+        <p class="def">No high-resolution (2x/3x) variant is provided, so the image can look soft on retina / high-DPR screens.</p>
+        <p class="fix"><b>Fix:</b> Provide a <code>srcset</code> with density descriptors, e.g. <code>image.jpg 1x, image@2x.jpg 2x</code>.</p>
+      </article>
+    </section>
+
+    <section>
+      <h2 class="help-group warning">Warning</h2>
+
+      <article class="help-item">
+        <h3>Next-gen format</h3>
+        <p class="def">The image is not served in a modern format (WebP or AVIF), which are significantly smaller than JPEG/PNG.</p>
+        <p class="fix"><b>Fix:</b> Serve WebP or AVIF, using a <code>&lt;picture&gt;</code> element with fallbacks, or an image CDN that negotiates the format automatically.</p>
+      </article>
+
+      <article class="help-item">
+        <h3>Lazy loading</h3>
+        <p class="def">A below-the-fold image is not lazy-loaded, so it competes for bandwidth with content the user can already see.</p>
+        <p class="fix"><b>Fix:</b> Add <code>loading="lazy"</code> to off-screen images. Do <em>not</em> lazy-load the LCP / above-the-fold hero image — that one should load eagerly.</p>
+      </article>
+
+      <article class="help-item">
+        <h3>LCP preload</h3>
+        <p class="def">The Largest Contentful Paint image is not preloaded, so the browser discovers it late and the page feels slower.</p>
+        <p class="fix"><b>Fix:</b> Add <code>&lt;link rel="preload" as="image" href="…"&gt;</code> (or <code>imagesrcset</code>/<code>imagesizes</code> for responsive images) for the LCP image in the document head.</p>
+      </article>
+    </section>
+
+    <section>
+      <h2 class="help-group info">Info</h2>
+
+      <article class="help-item">
+        <h3>LCP image</h3>
+        <p class="def">Identifies the Largest Contentful Paint image — the largest image visible above the fold. It is usually the most important image for perceived load speed.</p>
+        <p class="fix"><b>Tip:</b> Optimize this image first: load it eagerly, preload it, serve it in a next-gen format, and size it correctly.</p>
+      </article>
+
+      <article class="help-item">
+        <h3>Decoding</h3>
+        <p class="def">The LCP image does not use <code>decoding="sync"</code>. For the main hero image, synchronous decoding can help it paint sooner.</p>
+        <p class="fix"><b>Fix:</b> Set <code>decoding="sync"</code> and <code>loading="eager"</code> on the LCP image so the browser prioritizes it.</p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="help-footer">
+    <a href="https://www.oxyplug.com/docs/oxy-image-audit/?utm_source=extension&amp;utm_medium=chrome-extension&amp;utm_campaign=help" target="_blank" rel="noopener">Read the full guide on oxyplug.com &rarr;</a>
+  </footer>
+</div>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -39,7 +39,7 @@
     }
   ],
   "content_security_policy": {
-    "extension_pages": "default-src 'self'; img-src data:"
+    "extension_pages": "default-src 'self'; img-src 'self' data: https: http:"
   },
   "background": {
     "service_worker": "background.js"

--- a/popup.html
+++ b/popup.html
@@ -42,6 +42,7 @@
             <span>0%</span>
           </div>
         </div>
+        <div id="audit-summary" class="d-none"></div>
         <div class="oxyplug-tabs">
           <button id="all-issue" class="button button-small">
             All<span>0</span>


### PR DESCRIPTION
Report/help UX improvements (Chunk 2), for testing before merge.

### Popup report
- **Summary header** — grade pill + chips (image count, critical/warning/info, measured image weight) above the issue tabs.
- **Issue list** — thumbnail per image; issues sorted by severity (critical first).
- **Issue modal** — thumbnail of the audited image at the top of the Audit Report.

### Help (Learn) tab
- Flat list of ~17 "Learn More" links replaced with a **summary grouped by priority** (Critical / Warning / Info), each check with a friendly label + definition, and a single "See full definitions & fixes" link.
- That link opens a new **bundled, offline `help.html`** (with `assets/css/help.css`) — every check grouped by priority with a definition and a concrete fix. CSP-safe (external stylesheet only, no inline styles/scripts).

### Docs links
- Audit-modal per-issue "Learn More" links and the help-page footer point at the docs **Overview** (`docs/oxy-image-audit/`), which exists, instead of the not-yet-built `audit-definitions` page. Keeps a per-issue `utm_campaign` tag; drops the dead anchor.

### Robustness
- `Popup.postMessage` checks `runtime.lastError`, recovers the processing state, and tells the user to reload the page when the content script isn't in the tab (fixes the silent "Receiving end does not exist" dead-end).

### Manifest
- Relaxes `extension_pages` CSP `img-src` to `'self' data: https: http:` so audited images render as thumbnails in the popup. No permission changes.

## Test
Reload unpacked, **reload the target page**, audit → summary header + list thumbnails, critical-first ordering, thumbnail in the report modal. Open the **Help** tab → grouped summary; click "See full definitions & fixes" → offline help page opens in a new tab.